### PR TITLE
Add CMake config files for easy compilation.

### DIFF
--- a/CMake-Build.bat
+++ b/CMake-Build.bat
@@ -1,0 +1,8 @@
+
+mkdir build
+cd build
+cmake ..
+cmake --build .
+cd ..
+move "build\Debug\SnapKey.exe" "."
+rmdir /s /f build

--- a/CMake-Build.bat
+++ b/CMake-Build.bat
@@ -5,4 +5,4 @@ cmake ..
 cmake --build .
 cd ..
 move "build\Debug\SnapKey.exe" "."
-rmdir /s /f build
+rmdir /s /q build

--- a/CMake-Build.bat
+++ b/CMake-Build.bat
@@ -1,8 +1,13 @@
+@echo off
 
-mkdir build
-cd build
-cmake ..
-cmake --build .
-cd ..
-move "build\Debug\SnapKey.exe" "."
-rmdir /s /q build
+mkdir build > nul
+cd build > nul
+echo [+] Preparing files...
+cmake .. > nul
+echo [+] Compiling...
+cmake --build . > nul
+cd .. > nul
+move "build\Debug\SnapKey.exe" "." > nul
+echo [+] Done!
+rmdir /s /q build > nul
+pause > nul

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,13 @@
 cmake_minimum_required(VERSION 3.12)
 project(SnapKey)
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+# include_directories(${CMAKE_CURRENT_SOURCE_DIR}) --- unnecessary
+
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MTd")
+set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} /MT")
+set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} /MTd")
+set(BUILD_SHARED_LIBS OFF)
 
 add_executable(SnapKey SnapKey.cpp resources.rc)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.12)
+project(SnapKey)
+
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+
+add_executable(SnapKey SnapKey.cpp resources.rc)
+
+if (WIN32)
+    set_target_properties(SnapKey PROPERTIES
+        LINK_FLAGS "/SUBSYSTEM:WINDOWS /ENTRY:mainCRTStartup"
+    )
+endif()
+

--- a/resources.rc
+++ b/resources.rc
@@ -1,0 +1,1 @@
+IDI_ICON1 ICON "icon.ico"

--- a/resources.rc
+++ b/resources.rc
@@ -1,1 +1,1 @@
-IDI_ICON1 ICON "icon.ico"
+IDI_ICON1 ICON "snapkey.ico"


### PR DESCRIPTION
I was thinking some users (for ease of mind's sake) or even you @cafali would like a quick way to compile SnapKey so here is the config for CMake as well as a batch file `CMake-Build.bat` to make this process simple. If you want the executable to have the same icon as the one on release please just modify the `resources.rc` file and/or upload it to github.