### PR TITLE
hotfix for scancode casting

### DIFF
--- a/SnapKey.cpp
+++ b/SnapKey.cpp
@@ -6,7 +6,6 @@
 #include <sstream>
 #include <string>
 #include <unordered_map>
-
 #include <regex>
 
 using namespace std;
@@ -186,7 +185,7 @@ void SendKey(int targetKey, bool keyDown)
 {
     INPUT input = {0};
     input.ki.wVk = targetKey;
-    input.ki.wScan = MapVirtualKey((UINT) char(targetKey), 0);
+    input.ki.wScan = MapVirtualKey(targetKey, 0);
     input.type = INPUT_KEYBOARD;
 
     DWORD flags = KEYEVENTF_SCANCODE;


### PR DESCRIPTION
i double-casted to UINT (horrible idea) and then to char (even worse idea) in my testing of scancode limitations

i forgot to remove the casts

forgive me C++ gods.

(ref #57)