### PR TITLE
Add Random Delays in between KeyDown Handle

### DIFF
--- a/config.cfg
+++ b/config.cfg
@@ -7,6 +7,8 @@ key3=83
 key4=87
 
 
+random_delay_ms=(10,70)
+
 # After applying the changes, please restart SnapKey.
 # For further help, visit the README.pdf file.
 # More about rebinding keys - github.com/cafali/SnapKey/wiki/Rebinding-Keys


### PR DESCRIPTION
- Adding a simple random delays produced within a acceptable range seems to not trigger input automation detection systems (E.g CS2). This PR adds a randomly generated delay between key down handles which would look more natural 
- The Minimum and Maximum trigger delay in milliseconds can be configured through the `config.cfg` file by adding the line `random_delay_ms=(10,70)` where 10,70 ms is the random delay bounds.
- The above mentioned delay times seems to perform well and does not trigger the detection system. The more you reduce the delay more like you are to get detected. 10,70 ms felt like a sweet spot where 70ms still fast enough switching and won't get detected [until the another detection algorithm cracks this].